### PR TITLE
プレイリストに保存する際にキーの値も保存する機能を実装

### DIFF
--- a/app/models/playlist_song.rb
+++ b/app/models/playlist_song.rb
@@ -3,6 +3,7 @@
 # Table name: playlist_songs
 #
 #  id          :bigint           not null, primary key
+#  key         :integer          default(0), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  playlist_id :bigint           not null

--- a/app/models/playlist_song.rb
+++ b/app/models/playlist_song.rb
@@ -22,4 +22,6 @@
 class PlaylistSong < ApplicationRecord
   belongs_to :playlist
   belongs_to :song
+
+  validates :key, presence: true, inclusion: -6..6
 end

--- a/app/views/songs/new.html.erb
+++ b/app/views/songs/new.html.erb
@@ -12,6 +12,10 @@
             <%= f.text_field :title, placeholder: (t '.placeholder_title'), class: 'form-control' %>
           </div>
           <div class="mb-4">
+            <%= f.label :key, (t 'defaults.key'), class: 'form-label' %>
+            <%= f.select :key, options_for_select((-6..6).map { |n| [n == 0? '原キー' : (n > 0 ? "+#{n}" : n), n] }, selected: 0), {}, class: "form-select" %>
+          </div>
+          <div class="mb-4">
             <%= f.label :playlist_id, Playlist.model_name.human, class: 'form-label' %>
             <%= f.select :playlist_id, current_user.playlists.map { |n| [n.name, n.id] }, { include_blank: (t 'defaults.select_playlist') }, class: "form-select", required: true %>
             <div class="d-flex justify-content-end">

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -13,6 +13,7 @@ ja:
     search: 'さがす'
     settings: 'その他'
     playlist: 'リスト'
+    key: 'キー'
     terms_of_service: '利用規約'
     privacy_policy: 'プライバシーポリシー'
     placeholder: '曲名かアーティスト名で検索できます'
@@ -21,6 +22,7 @@ ja:
     select_playlist: 'プレイリストを選択してください'
     require_login: 'ログインしてください。'
     select_playlist: 'プレイリストを選択してください'
+    select_key: 'キーを選択してください'
     require_login: 'ログインしてください。'
   users:
     new:
@@ -72,6 +74,6 @@ ja:
     new:
       placeholder_artist: '歌手名を入力してください'
       placeholder_title: '曲名を入力してください'
-      not_have_playlist: 'プレイリストの作成はこちら'
+      not_have_playlist: 'プレイリスト作成ページ'
     create:
       success: '%{item}に追加しました。'

--- a/db/migrate/20230627084858_add_key_to_playlist_songs.rb
+++ b/db/migrate/20230627084858_add_key_to_playlist_songs.rb
@@ -1,0 +1,5 @@
+class AddKeyToPlaylistSongs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :playlist_songs, :key, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_26_084152) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_27_084858) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_26_084152) do
     t.bigint "song_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "key", default: 0, null: false
     t.index ["playlist_id"], name: "index_playlist_songs_on_playlist_id"
     t.index ["song_id"], name: "index_playlist_songs_on_song_id"
   end


### PR DESCRIPTION
keysテーブルの作成ではなく、playlist_songsにkeyカラムを追加。
楽曲を作成して、プレイリストに保存する際に、キーの値を選択し、選択した値がplaylist_songsテーブルに保存するようにしました。